### PR TITLE
Fix the scope of slf4j-simple

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,6 +242,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>1.7.25</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
The scope probably got messed up when cleaning up POM. This
is a test dependency.