### PR TITLE
Update and plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.lambdazen.bitsy</groupId>
   <artifactId>bitsy</artifactId>
-  <version>3.0.0</version>
+  <version>3.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Bitsy Graph Database</name>
@@ -40,8 +40,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- versions -->
-    <gremlin.version>3.2.6</gremlin.version>
-    <jackson.version>2.9.1</jackson.version>
+    <gremlin.version>3.3.0</gremlin.version>
+    <jackson.version>2.9.2</jackson.version>
   </properties>
 
   <repositories>
@@ -95,6 +95,10 @@
             <java.awt.headless>true</java.awt.headless>
             <java.io.tmpdir>${java.io.tmpdir}</java.io.tmpdir>
           </systemPropertyVariables>
+          <includes>
+            <include>**/*Test.java</include>
+            <include>**/*TestCase.java</include>
+          </includes>
         </configuration>
       </plugin>
 
@@ -113,6 +117,11 @@
             <java.awt.headless>true</java.awt.headless>
             <java.io.tmpdir>${java.io.tmpdir}</java.io.tmpdir>
           </systemPropertyVariables>
+          <includes>
+            <include>**/*IT.java</include>
+            <include>**/*ITCase.java</include>
+            <include>**/*TestSuite.java</include>
+          </includes>
         </configuration>
       </plugin>
 

--- a/src/main/java/com/lambdazen/bitsy/jsr223/BitsyGremlinPlugin.java
+++ b/src/main/java/com/lambdazen/bitsy/jsr223/BitsyGremlinPlugin.java
@@ -1,0 +1,41 @@
+package com.lambdazen.bitsy.jsr223;
+
+import com.lambdazen.bitsy.BitsyEdge;
+import com.lambdazen.bitsy.BitsyElement;
+import com.lambdazen.bitsy.BitsyGraph;
+import com.lambdazen.bitsy.BitsyProperty;
+import com.lambdazen.bitsy.BitsyVertex;
+import com.lambdazen.bitsy.BitsyVertexProperty;
+import com.lambdazen.bitsy.ThreadedBitsyGraph;
+import com.lambdazen.bitsy.tx.BitsyTransaction;
+import org.apache.tinkerpop.gremlin.jsr223.AbstractGremlinPlugin;
+import org.apache.tinkerpop.gremlin.jsr223.DefaultImportCustomizer;
+import org.apache.tinkerpop.gremlin.jsr223.ImportCustomizer;
+
+public class BitsyGremlinPlugin
+    extends AbstractGremlinPlugin
+{
+  private static final String NAME = "lambdazen.bitsy";
+
+  private static final ImportCustomizer imports() {
+    return DefaultImportCustomizer.build()
+        .addClassImports(BitsyEdge.class,
+            BitsyElement.class,
+            BitsyGraph.class,
+            ThreadedBitsyGraph.class,
+            BitsyProperty.class,
+            BitsyVertex.class,
+            BitsyVertexProperty.class,
+            BitsyTransaction.class).create();
+  }
+
+  private static final BitsyGremlinPlugin INSTANCE = new BitsyGremlinPlugin();
+
+  public BitsyGremlinPlugin() {
+    super(NAME, imports());
+  }
+
+  public static BitsyGremlinPlugin instance() {
+    return INSTANCE;
+  }
+}

--- a/src/main/java/com/lambdazen/bitsy/tx/BitsyTransaction.java
+++ b/src/main/java/com/lambdazen/bitsy/tx/BitsyTransaction.java
@@ -510,11 +510,6 @@ public class BitsyTransaction implements ITransaction, ICommitChanges {
 
     // Added for Tinkerpop 3    
 	@Override
-	public <R> Workload<R> submit(Function<Graph, R> work) {
-		return new Workload<>(graph, work);
-	}
-
-	@Override
 	public void readWrite() {
 		context.getReadWriteConsumer().accept(this);
 	}

--- a/src/test/java/com/lambdazen/bitsy/structure/BitsyProcessStandardTestSuite.java
+++ b/src/test/java/com/lambdazen/bitsy/structure/BitsyProcessStandardTestSuite.java
@@ -1,12 +1,9 @@
 package com.lambdazen.bitsy.structure;
 
+import com.lambdazen.bitsy.BitsyGraph;
 import org.apache.tinkerpop.gremlin.AbstractGremlinSuite;
 import org.apache.tinkerpop.gremlin.GraphProviderClass;
-import org.apache.tinkerpop.gremlin.process.ProcessStandardSuite;
-import org.apache.tinkerpop.gremlin.process.traversal.CoreTraversalTest;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine;
-import org.apache.tinkerpop.gremlin.process.traversal.TraversalInterruptionTest;
-import org.apache.tinkerpop.gremlin.process.traversal.step.ComplexTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.branch.BranchTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.branch.ChooseTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.branch.LocalTest;
@@ -34,11 +31,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.ConstantTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.CountTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.FlatMapTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.FoldTest;
-import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.LoopsTest;
-import org.apache.tinkerpop.gremlin.process.traversal.step.map.MapKeysTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MapTest;
-import org.apache.tinkerpop.gremlin.process.traversal.step.map.MapValuesTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MatchTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MaxTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.MeanTest;
@@ -54,10 +48,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.UnfoldTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.ValueMapTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.AggregateTest;
-import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.ExplainTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.GroupCountTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.GroupTest;
-import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.GroupTestV3d0;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.InjectTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.SackTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.SideEffectCapTest;
@@ -65,17 +57,9 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.SideEffect
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.StoreTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.SubgraphTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.TreeTest;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.ElementIdStrategyProcessTest;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.EventStrategyProcessTest;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.PartitionStrategyProcessTest;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategyProcessTest;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.TranslationStrategyProcessTest;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.ReadOnlyStrategyProcessTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.RunnerBuilder;
-
-import com.lambdazen.bitsy.BitsyGraph;
 
 @RunWith(BitsyProcessStandardTestSuite.class)
 @GraphProviderClass(provider = BitsyTestGraphProvider.class, graph = BitsyGraph.class)
@@ -207,8 +191,8 @@ public class BitsyProcessStandardTestSuite extends AbstractGremlinSuite {
             FoldTest.class,
             LoopsTest.class,
             MapTest.class,
-            MapKeysTest.class,
-            MapValuesTest.class,
+            //MapKeysTest.class,
+            //MapValuesTest.class,
             MatchTest.class,
             MaxTest.class,
             MeanTest.class,


### PR DESCRIPTION
This makes Bitsy3 usable within Tinkerpop3 Gremlin Server.

Changes in POM:
* bump to tinkerpop 3.3.0
* bump jackson to 2.9.2
* sort out tests left out

Added `BitsyGremlinPlugin` that makes Bitsy usable in TP3 tools like server.