### PR TITLE
Bitsy plugin uuid fix

### DIFF
--- a/src/main/java/com/lambdazen/bitsy/BitsyGraph.java
+++ b/src/main/java/com/lambdazen/bitsy/BitsyGraph.java
@@ -22,6 +22,9 @@ import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.io.Io;
+import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONVersion;
+import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoVersion;
 import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -337,6 +340,11 @@ public class BitsyGraph implements Graph, BitsyGraphMBean {
     @Override
     public GraphComputer compute(Class graphComputerClass) {
     	throw new UnsupportedOperationException("Bitsy doesn't support the compute() method", new BitsyException(BitsyErrorCodes.NO_OLAP_SUPPORT));
+    }
+
+    @Override
+    public <I extends Io> I io(final Io.Builder<I> builder) {
+        return (I) builder.graph(this).onMapper(m -> m.addRegistry(BitsyIoRegistryV3d0.instance())).create();
     }
 
     /* FEATURES */

--- a/src/main/java/com/lambdazen/bitsy/BitsyIoRegistryV3d0.java
+++ b/src/main/java/com/lambdazen/bitsy/BitsyIoRegistryV3d0.java
@@ -1,0 +1,39 @@
+package com.lambdazen.bitsy;
+
+import org.apache.tinkerpop.gremlin.structure.io.AbstractIoRegistry;
+import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoIo;
+import org.apache.tinkerpop.shaded.kryo.Kryo;
+import org.apache.tinkerpop.shaded.kryo.Serializer;
+import org.apache.tinkerpop.shaded.kryo.io.Input;
+import org.apache.tinkerpop.shaded.kryo.io.Output;
+
+public class BitsyIoRegistryV3d0
+    extends AbstractIoRegistry
+{
+  private static final BitsyIoRegistryV3d0 INSTANCE = new BitsyIoRegistryV3d0();
+
+  private BitsyIoRegistryV3d0() {
+    register(GryoIo.class, UUID.class, new UUIDGryoSerializer());
+  }
+
+  public static BitsyIoRegistryV3d0 instance() {
+    return INSTANCE;
+  }
+
+  final static class UUIDGryoSerializer
+      extends Serializer<UUID>
+  {
+    @Override
+    public void write(final Kryo kryo, final Output output, final UUID uuid) {
+      output.writeLong(uuid.getMostSignificantBits());
+      output.writeLong(uuid.getLeastSignificantBits());
+    }
+
+    @Override
+    public UUID read(final Kryo kryo, final Input input, final Class<UUID> aClass) {
+      long msb = input.readLong();
+      long lsb = input.readLong();
+      return new UUID(msb, lsb);
+    }
+  }
+}

--- a/src/main/java/com/lambdazen/bitsy/jsr223/BitsyGremlinPlugin.java
+++ b/src/main/java/com/lambdazen/bitsy/jsr223/BitsyGremlinPlugin.java
@@ -3,6 +3,7 @@ package com.lambdazen.bitsy.jsr223;
 import com.lambdazen.bitsy.BitsyEdge;
 import com.lambdazen.bitsy.BitsyElement;
 import com.lambdazen.bitsy.BitsyGraph;
+import com.lambdazen.bitsy.BitsyIoRegistryV3d0;
 import com.lambdazen.bitsy.BitsyProperty;
 import com.lambdazen.bitsy.BitsyVertex;
 import com.lambdazen.bitsy.BitsyVertexProperty;
@@ -18,9 +19,10 @@ public class BitsyGremlinPlugin
 {
   private static final String NAME = "lambdazen.bitsy";
 
-  private static final ImportCustomizer imports() {
+  private static ImportCustomizer imports() {
     return DefaultImportCustomizer.build()
-        .addClassImports(BitsyEdge.class,
+        .addClassImports(
+            BitsyEdge.class,
             BitsyElement.class,
             BitsyGraph.class,
             ThreadedBitsyGraph.class,
@@ -28,12 +30,14 @@ public class BitsyGremlinPlugin
             BitsyVertex.class,
             BitsyVertexProperty.class,
             UUID.class,
-            BitsyTransaction.class).create();
+            BitsyTransaction.class,
+            BitsyIoRegistryV3d0.class
+        ).create();
   }
 
   private static final BitsyGremlinPlugin INSTANCE = new BitsyGremlinPlugin();
 
-  public BitsyGremlinPlugin() {
+  private BitsyGremlinPlugin() {
     super(NAME, imports());
   }
 

--- a/src/main/java/com/lambdazen/bitsy/jsr223/BitsyGremlinPlugin.java
+++ b/src/main/java/com/lambdazen/bitsy/jsr223/BitsyGremlinPlugin.java
@@ -7,6 +7,7 @@ import com.lambdazen.bitsy.BitsyProperty;
 import com.lambdazen.bitsy.BitsyVertex;
 import com.lambdazen.bitsy.BitsyVertexProperty;
 import com.lambdazen.bitsy.ThreadedBitsyGraph;
+import com.lambdazen.bitsy.UUID;
 import com.lambdazen.bitsy.tx.BitsyTransaction;
 import org.apache.tinkerpop.gremlin.jsr223.AbstractGremlinPlugin;
 import org.apache.tinkerpop.gremlin.jsr223.DefaultImportCustomizer;
@@ -26,6 +27,7 @@ public class BitsyGremlinPlugin
             BitsyProperty.class,
             BitsyVertex.class,
             BitsyVertexProperty.class,
+            UUID.class,
             BitsyTransaction.class).create();
   }
 

--- a/src/main/resources/META-INF/services/org.apache.tinkerpop.gremlin.jsr223.GremlinPlugin
+++ b/src/main/resources/META-INF/services/org.apache.tinkerpop.gremlin.jsr223.GremlinPlugin
@@ -1,0 +1,1 @@
+com.lambdazen.bitsy.jsr223.BitsyGremlinPlugin


### PR DESCRIPTION
But all this seems not enough, at least TP3 Server reports even with this code (bitsy is deployed to `ext` of TP3 Server):

```
[WARN] AbstractGryoMessageSerializerV3d0 - Response [ResponseMessage{requestId=6144d7db-219d-4e4d-a169-7f3bb91ee51b, status=ResponseStatus{code=SUCCESS, message='', attributes={}}, result=ResponseResult{data=[v[f2b69785-bbab-477f-90a1-e5b781eb724a]], meta={}}}] could not be serialized by org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0.
[WARN] AbstractOpProcessor - The result [[v[f2b69785-bbab-477f-90a1-e5b781eb724a]]] in the request 6144d7db-219d-4e4d-a169-7f3bb91ee51b could not be serialized and returned.
org.apache.tinkerpop.gremlin.driver.ser.SerializationException: org.apache.tinkerpop.shaded.kryo.KryoException: java.lang.IllegalArgumentException: Class is not registered: com.lambdazen.bitsy.UUID
Note: To register this class use: kryo.register(com.lambdazen.bitsy.UUID.class);
Serialization trace:
id (org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertex)
	at org.apache.tinkerpop.gremlin.driver.ser.AbstractGryoMessageSerializerV3d0.serializeResponseAsBinary(AbstractGryoMessageSerializerV3d0.java:193)
	at org.apache.tinkerpop.gremlin.server.op.AbstractOpProcessor.makeFrame(AbstractOpProcessor.java:266)
	at org.apache.tinkerpop.gremlin.server.op.traversal.TraversalOpProcessor.handleIterator(TraversalOpProcessor.java:542)
	at org.apache.tinkerpop.gremlin.server.op.traversal.TraversalOpProcessor.lambda$iterateBytecodeTraversal$4(TraversalOpProcessor.java:389)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: org.apache.tinkerpop.shaded.kryo.KryoException: java.lang.IllegalArgumentException: Class is not registered: com.lambdazen.bitsy.UUID
Note: To register this class use: kryo.register(com.lambdazen.bitsy.UUID.class);
Serialization trace:
id (org.apache.tinkerpop.gremlin.structure.util.reference.ReferenceVertex)
	at org.apache.tinkerpop.shaded.kryo.serializers.ObjectField.write(ObjectField.java:101)
	at org.apache.tinkerpop.shaded.kryo.serializers.FieldSerializer.write(FieldSerializer.java:524)
	at org.apache.tinkerpop.shaded.kryo.Kryo.writeClassAndObject(Kryo.java:625)
	at org.apache.tinkerpop.gremlin.structure.io.gryo.kryoshim.shaded.ShadedKryoAdapter.writeClassAndObject(ShadedKryoAdapter.java:49)
	at org.apache.tinkerpop.gremlin.structure.io.gryo.kryoshim.shaded.ShadedKryoAdapter.writeClassAndObject(ShadedKryoAdapter.java:24)
	at org.apache.tinkerpop.gremlin.structure.io.gryo.GryoSerializersV3d0$DefaultRemoteTraverserSerializer.write(GryoSerializersV3d0.java:389)
	at org.apache.tinkerpop.gremlin.structure.io.gryo.GryoSerializersV3d0$DefaultRemoteTraverserSerializer.write(GryoSerializersV3d0.java:386)
	at org.apache.tinkerpop.gremlin.structure.io.gryo.kryoshim.shaded.ShadedSerializerAdapter.write(ShadedSerializerAdapter.java:44)
	at org.apache.tinkerpop.shaded.kryo.Kryo.writeClassAndObject(Kryo.java:625)
	at org.apache.tinkerpop.shaded.kryo.serializers.CollectionSerializer.write(CollectionSerializer.java:100)
	at org.apache.tinkerpop.shaded.kryo.serializers.CollectionSerializer.write(CollectionSerializer.java:40)
	at org.apache.tinkerpop.shaded.kryo.Kryo.writeClassAndObject(Kryo.java:625)
	at org.apache.tinkerpop.gremlin.structure.io.gryo.kryoshim.shaded.ShadedKryoAdapter.writeClassAndObject(ShadedKryoAdapter.java:49)
	at org.apache.tinkerpop.gremlin.structure.io.gryo.kryoshim.shaded.ShadedKryoAdapter.writeClassAndObject(ShadedKryoAdapter.java:24)
	at org.apache.tinkerpop.gremlin.driver.ser.ResponseMessageGryoSerializer.write(ResponseMessageGryoSerializer.java:45)
	at org.apache.tinkerpop.gremlin.driver.ser.ResponseMessageGryoSerializer.write(ResponseMessageGryoSerializer.java:34)
	at org.apache.tinkerpop.gremlin.structure.io.gryo.kryoshim.shaded.ShadedSerializerAdapter.write(ShadedSerializerAdapter.java:44)
	at org.apache.tinkerpop.shaded.kryo.Kryo.writeObject(Kryo.java:531)
	at org.apache.tinkerpop.gremlin.driver.ser.AbstractGryoMessageSerializerV3d0.serializeResponseAsBinary(AbstractGryoMessageSerializerV3d0.java:177)
	... 9 more
Caused by: java.lang.IllegalArgumentException: Class is not registered: com.lambdazen.bitsy.UUID
Note: To register this class use: kryo.register(com.lambdazen.bitsy.UUID.class);
	at org.apache.tinkerpop.shaded.kryo.Kryo.getRegistration(Kryo.java:484)
	at org.apache.tinkerpop.gremlin.structure.io.gryo.AbstractGryoClassResolver.writeClass(AbstractGryoClassResolver.java:110)
	at org.apache.tinkerpop.shaded.kryo.Kryo.writeClass(Kryo.java:514)
	at org.apache.tinkerpop.shaded.kryo.serializers.ObjectField.write(ObjectField.java:76)
	... 27 more

```