### PR TITLE
Remove NessUUID dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,12 +267,6 @@
       <version>1.7.25</version>
     </dependency>
 
-    <dependency>
-      <groupId>com.nesscomputing.components</groupId>
-      <artifactId>ness-core</artifactId>
-      <version>1.9.1</version>
-    </dependency>
-
 <!-- UNCOMMENT IF REQUIRE -->
 	<dependency>
 	    <groupId>com.google.guava</groupId>

--- a/src/main/java/com/lambdazen/bitsy/UUID.java
+++ b/src/main/java/com/lambdazen/bitsy/UUID.java
@@ -1,7 +1,6 @@
 package com.lambdazen.bitsy;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.nesscomputing.uuid.NessUUID;
 
 /** This class captures a UUID and is modeled after java.util.UUID */
 public class UUID implements Comparable<UUID> {
@@ -33,11 +32,11 @@ public class UUID implements Comparable<UUID> {
     }
     
     public String uuidRepr() {
-        return NessUUID.toString(mostSigBits, leastSigBits);
+        return new java.util.UUID(mostSigBits, leastSigBits).toString();
     }
     
     public static UUID fromString(String str) {
-        java.util.UUID ans = NessUUID.fromString(str);
+        java.util.UUID ans = java.util.UUID.fromString(str);
         
         return new UUID(ans.getMostSignificantBits(), ans.getLeastSignificantBits());
     }
@@ -87,6 +86,6 @@ public class UUID implements Comparable<UUID> {
     }
 
     public static String toString(UUID obj) {
-        return NessUUID.toString(obj.getMostSignificantBits(), obj.getLeastSignificantBits());
+        return new java.util.UUID(obj.getMostSignificantBits(), obj.getLeastSignificantBits()).toString();
     }
 }

--- a/src/main/java/com/lambdazen/bitsy/store/VertexBeanJson.java
+++ b/src/main/java/com/lambdazen/bitsy/store/VertexBeanJson.java
@@ -10,7 +10,6 @@ import com.lambdazen.bitsy.BitsyState;
 import com.lambdazen.bitsy.UUID;
 import com.lambdazen.bitsy.ads.dict.Dictionary;
 import com.lambdazen.bitsy.ads.dict.DictionaryFactory;
-import com.nesscomputing.uuid.NessUUID;
 
 @JsonPropertyOrder({"id", "v", "s", "p"})
 public final class VertexBeanJson extends VertexBean implements Serializable {


### PR DESCRIPTION
NessUUID seems no more mantained and modern JDK resolved some problems about UUID:
https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6611830.

This patch uses standard JDK UUID instead of NessUUID to prevent this error:

```
[INFO] FileBackedMemoryGraphStore - Starting graph FileBackedMemoryGraphStore-1(path = /tinkerpop/store)
java.lang.NoSuchMethodException: java.lang.String.<init>([C, boolean)
        at java.base/java.lang.Class.getConstructor0(Class.java:3349)
        at java.base/java.lang.Class.getDeclaredConstructor(Class.java:2553)
        at com.nesscomputing.uuid.NessUUID.<clinit>(NessUUID.java:181)
        at com.lambdazen.bitsy.UUID.fromString(UUID.java:40)
        at com.lambdazen.bitsy.store.VertexBeanJson.<init>(VertexBeanJson.java:27)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
        at com.fasterxml.jackson.databind.introspect.AnnotatedConstructor.call(AnnotatedConstructor.java:124)
        at com.fasterxml.jackson.databind.deser.std.StdValueInstantiator.createFromObjectWith(StdValueInstantiator.java:283)
        at com.fasterxml.jackson.databind.deser.ValueInstantiator.createFromObjectWith(ValueInstantiator.java:229)
        at com.fasterxml.jackson.databind.deser.impl.PropertyBasedCreator.build(PropertyBasedCreator.java:198)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:422)
        at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1287)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:326)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:159)
        at com.fasterxml.jackson.databind.ObjectReader._bindAndClose(ObjectReader.java:1719)
        at com.fasterxml.jackson.databind.ObjectReader.readValue(ObjectReader.java:1261)
        at com.lambdazen.bitsy.store.Record.deserialize(Record.java:64)
        at com.lambdazen.bitsy.store.RecordReader.next(RecordReader.java:30)
        at com.lambdazen.bitsy.store.LoadTask.run(LoadTask.java:86)
        at com.lambdazen.bitsy.store.FileBackedMemoryGraphStore.<init>(FileBackedMemoryGraphStore.java:169)
        at com.lambdazen.bitsy.BitsyGraph.<init>(BitsyGraph.java:151)
        at com.lambdazen.bitsy.BitsyGraph.<init>(BitsyGraph.java:173)
        at com.lambdazen.bitsy.BitsyGraph.open(BitsyGraph.java:208)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.apache.tinkerpop.gremlin.structure.util.GraphFactory.open(GraphFactory.java:77)
        at org.apache.tinkerpop.gremlin.structure.util.GraphFactory.open(GraphFactory.java:69)
        at org.apache.tinkerpop.gremlin.structure.util.GraphFactory.open(GraphFactory.java:103)
        at org.apache.tinkerpop.gremlin.server.util.DefaultGraphManager.lambda$new$0(DefaultGraphManager.java:57)
        at java.base/java.util.LinkedHashMap$LinkedEntrySet.forEach(LinkedHashMap.java:671)
        at org.apache.tinkerpop.gremlin.server.util.DefaultGraphManager.<init>(DefaultGraphManager.java:55)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
        at org.apache.tinkerpop.gremlin.server.util.ServerGremlinExecutor.<init>(ServerGremlinExecutor.java:80)
        at org.apache.tinkerpop.gremlin.server.GremlinServer.<init>(GremlinServer.java:123)
        at org.apache.tinkerpop.gremlin.server.GremlinServer.<init>(GremlinServer.java:86)
        at org.apache.tinkerpop.gremlin.server.GremlinServer.main(GremlinServer.java:351)
```
Reference issue: #30 