### PR TITLE
Bulk update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ on:
 jobs:
   build:
     name: Verify
-    uses: maveniverse/parent/.github/workflows/ci.yml@release-51
+    uses: maveniverse/parent/.github/workflows/ci.yml@release-55
     with:
       maven-test-run: false # ITs are currently busted and needs to go to separate module
-      jdk-matrix: '[ "8", "17", "21", "25" ]'
-      maven-matrix: '[ "3.9.12" ]'
+      jdk-matrix: '[ "8", "21", "26" ]'
+      maven-matrix: '[ "3.9.16" ]'
       maven-test: './mvnw clean verify -e -B -V -P run-its'

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,3 +1,3 @@
 wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>eu.maveniverse.maven.parent</groupId>
     <artifactId>parent</artifactId>
-    <version>51</version>
+    <version>55</version>
   </parent>
 
   <groupId>com.lambdazen.bitsy</groupId>
@@ -52,7 +52,7 @@
     <maven.compiler.release>8</maven.compiler.release>
 
     <!-- versions -->
-    <gremlin.version>3.7.5</gremlin.version>
+    <gremlin.version>3.8.1</gremlin.version>
     <slf4j.version>1.7.36</slf4j.version>
 
     <!-- JaCoCo: empty -->
@@ -62,9 +62,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>2.21.1</version>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>2.22.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/com/lambdazen/bitsy/gremlin/BitsyGraphStep.java
+++ b/src/main/java/com/lambdazen/bitsy/gremlin/BitsyGraphStep.java
@@ -23,7 +23,7 @@ import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 
 // Bitsy graph step based Tinkerpop's Neo4j implementation
-public final class BitsyGraphStep<S, E extends Element> extends GraphStep<S, E> implements HasContainerHolder {
+public final class BitsyGraphStep<S, E extends Element> extends GraphStep<S, E> implements HasContainerHolder<S, E> {
 
     private final List<HasContainer> hasContainers = new ArrayList<>();
 

--- a/src/main/java/com/lambdazen/bitsy/gremlin/BitsyTraversalStrategy.java
+++ b/src/main/java/com/lambdazen/bitsy/gremlin/BitsyTraversalStrategy.java
@@ -3,7 +3,6 @@ package com.lambdazen.bitsy.gremlin;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.step.HasContainerHolder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.NoOpBarrierStep;
@@ -22,12 +21,12 @@ public class BitsyTraversalStrategy extends AbstractTraversalStrategy<TraversalS
     @Override
     public void apply(final Traversal.Admin<?, ?> traversal) {
         for (final GraphStep originalGraphStep : TraversalHelper.getStepsOfClass(GraphStep.class, traversal)) {
-            final BitsyGraphStep<?, ?> bitsyGraphStep = new BitsyGraphStep<>(originalGraphStep);
+            final BitsyGraphStep bitsyGraphStep = new BitsyGraphStep<>(originalGraphStep);
             TraversalHelper.replaceStep(originalGraphStep, bitsyGraphStep, traversal);
-            Step<?, ?> currentStep = bitsyGraphStep.getNextStep();
+            Step currentStep = bitsyGraphStep.getNextStep();
             while (currentStep instanceof HasStep || currentStep instanceof NoOpBarrierStep) {
                 if (currentStep instanceof HasStep) {
-                    for (final HasContainer hasContainer : ((HasContainerHolder) currentStep).getHasContainers()) {
+                    for (final HasContainer hasContainer : ((HasStep<?>) currentStep).getHasContainers()) {
                         if (!GraphStep.processHasContainerIds(bitsyGraphStep, hasContainer))
                             bitsyGraphStep.addHasContainer(hasContainer);
                     }

--- a/src/main/java/com/lambdazen/bitsy/util/CommittableFileLog.java
+++ b/src/main/java/com/lambdazen/bitsy/util/CommittableFileLog.java
@@ -81,7 +81,7 @@ public class CommittableFileLog {
         while (!endReached) {
             if (charBuf == null) { //  || (charBuf.length() <= index)
                 // Read next
-                byteBuf.clear();
+                clear(byteBuf);
                 int bytesRead;
                 try {
                     bytesRead = fileChannel.read(byteBuf);
@@ -100,7 +100,7 @@ public class CommittableFileLog {
                 }
 
                 // Get more chars into the buffer
-                byteBuf.flip();
+                flip(byteBuf);
 
                 charBuf = FileBackedMemoryGraphStore.utf8.decode(byteBuf);
 
@@ -389,6 +389,7 @@ public class CommittableFileLog {
         }
     }
 
+    @Override
     public String toString() {
         return "CommittableFileLog(" + filePath + ")";
     }
@@ -407,5 +408,13 @@ public class CommittableFileLog {
 
     public static void setLockMode(boolean b) {
         LOCK_MODE = b;
+    }
+
+    private static void clear(ByteBuffer buffer) {
+        buffer.clear();
+    }
+
+    private static void flip(ByteBuffer buffer) {
+        buffer.flip();
     }
 }

--- a/src/test/java/com/lambdazen/bitsy/ads/set/SetTest.java
+++ b/src/test/java/com/lambdazen/bitsy/ads/set/SetTest.java
@@ -1,7 +1,7 @@
 package com.lambdazen.bitsy.ads.set;
 
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
@@ -208,8 +208,8 @@ public class SetTest extends TestCase {
         List myKeys = Arrays.asList(keys);
         List refKeys = Arrays.asList(reference.toArray());
 
-        Collections.sort(myKeys);
-        Collections.sort(refKeys);
+        myKeys.sort(Comparator.naturalOrder());
+        refKeys.sort(Comparator.naturalOrder());
 
         assertEquals(reference.size(), keys.length);
         assertEquals(reference.size(), CompactSet.size(set));

--- a/src/test/java/com/lambdazen/bitsy/structure/BitsyProcessStandardTestSuite.java
+++ b/src/test/java/com/lambdazen/bitsy/structure/BitsyProcessStandardTestSuite.java
@@ -54,7 +54,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.InjectTest
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.SackTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.SideEffectCapTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.SideEffectTest;
-import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.StoreTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.SubgraphTest;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.TreeTest;
 import org.junit.runner.RunWith;
@@ -215,7 +214,6 @@ public class BitsyProcessStandardTestSuite extends AbstractGremlinSuite {
         SackTest.class,
         SideEffectCapTest.class,
         SideEffectTest.class,
-        StoreTest.class,
         SubgraphTest.class,
         TreeTest.class,
     };


### PR DESCRIPTION
Changes:
* parent POM to 55 (and CI)
* Jackson 2.22.0
* TinkerPop 3.8.1
* modernizer rules applied
* workaround for `ByteBuffer` compiled on JDK9+